### PR TITLE
Fix sensor naming to avoid crashing homebridge on duplicates.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,8 +43,7 @@ class TelldusTDToolPlatform {
     }).then(devices => {
       return TDtool.listSensors().then(sensors => {
         this.log(foundOfTypeString('sensor', sensors.length))
-        sensors.forEach((current, index) => {
-          sensors[index].name = 'Thermometer'})
+        sensors.forEach((current, index) => {sensors[index].name = `Thermometer ${current.id}`})
         return devices.concat(sensors)
       })
     }).then(accessories => {


### PR DESCRIPTION
Starting homebridge with 9 sensors made it crash with no error on registering the second sensor.

```
[10/9/2016, 5:30:17 PM] [Telldus-TD-Tool] Initializing Telldus-TD-Tool platform...
[10/9/2016, 5:30:17 PM] [Telldus-TD-Tool] Loading devices...
[10/9/2016, 5:30:17 PM] [Telldus-TD-Tool] Found no items of type "device".
[10/9/2016, 5:30:17 PM] [Telldus-TD-Tool] Found 9 items of type "sensor".
[10/9/2016, 5:30:17 PM] [Telldus-TD-Tool] Initializing platform accessory 'Thermometer'...
[10/9/2016, 5:30:17 PM] [Telldus-TD-Tool] Initializing platform accessory 'Thermometer'...
```

This PR add's the sensor's ID to the name and makes it visible in Homekit.

```
[10/9/2016, 5:33:15 PM] [Telldus-TD-Tool] Initializing Telldus-TD-Tool platform...
[10/9/2016, 5:33:15 PM] [Telldus-TD-Tool] Loading devices...
[10/9/2016, 5:33:15 PM] [Telldus-TD-Tool] Found no items of type "device".
[10/9/2016, 5:33:15 PM] [Telldus-TD-Tool] Found 9 items of type "sensor".
[10/9/2016, 5:33:15 PM] [Telldus-TD-Tool] Initializing platform accessory 'Thermometer 31'...
[10/9/2016, 5:33:15 PM] [Telldus-TD-Tool] Initializing platform accessory 'Thermometer 11'...
[10/9/2016, 5:33:15 PM] [Telldus-TD-Tool] Initializing platform accessory 'Thermometer 142'...
[10/9/2016, 5:33:15 PM] [Telldus-TD-Tool] Initializing platform accessory 'Thermometer 113'...
[10/9/2016, 5:33:15 PM] [Telldus-TD-Tool] Initializing platform accessory 'Thermometer 114'...
[10/9/2016, 5:33:15 PM] [Telldus-TD-Tool] Initializing platform accessory 'Thermometer 41'...
[10/9/2016, 5:33:15 PM] [Telldus-TD-Tool] Initializing platform accessory 'Thermometer 121'...
[10/9/2016, 5:33:15 PM] [Telldus-TD-Tool] Initializing platform accessory 'Thermometer 61'...
[10/9/2016, 5:33:15 PM] [Telldus-TD-Tool] Initializing platform accessory 'Thermometer 74'...
```

I'm not sure how this works in homekit after renaming and restarting, so it might require some testing still.
