### PR TITLE
Add support for negative temperatures

### DIFF
--- a/src/lib/telldus-accessory.js
+++ b/src/lib/telldus-accessory.js
@@ -275,6 +275,9 @@ class TelldusThermometer extends TelldusAccessory {
    * Return the supported services by this Accessory. This only supports
    * fetching of the temperature.
    *
+   * Homebridges default minValue is 0, which can't handle negative temperatures.
+   * We'll set it to -50 which should cover most usecases.
+   *
    * @return {Array} An array of services supported by this accessory.
    */
   getServices() {
@@ -282,6 +285,8 @@ class TelldusThermometer extends TelldusAccessory {
 
     controllerService.getCharacteristic(
       this.Characteristic.CurrentTemperature
+    ).setProps(
+      { minValue: -50 }
     ).on('get', this.getTemperature.bind(this))
 
     return [controllerService]


### PR DESCRIPTION
The default characteristics does not support negative temperatures. This is not logged as an error anywhere, but the data is not passed on to homekit.

Fix is done according to comment here: https://github.com/nfarina/homebridge/issues/480#issuecomment-173663221

_NOTE:_ This PR contains also my other PR, so please review/merge that first.
