### PR TITLE
Temperature sensors wrongly identified as `temperaturehumidity` will spam homekit with 0% humidity.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,12 @@ class TelldusTDToolPlatform {
       })
     }).then(accessories => {
       callback(accessories.map(data => {
-        const Accessory = modelToAccessoryMap[data.model.split(':')[0]]
+        let Accessory = modelToAccessoryMap[data.model.split(':')[0]];
+        // Some ESIC thermometers wrongly identifies themselves as temperaturehumidity and keeps sending 0% humidity.
+        // We identify them by having humidity at zero, and override their type to avoid false sensors in homekit.
+        if (Accessory === TelldusThermometerHygrometer && parseFloat(data.humidity) < 1) {
+          Accessory = TelldusThermometer;
+        }
 
         if (Accessory === undefined) {
           this.log(


### PR DESCRIPTION
Some temperature senors are wrongly identifying them as `temperaturehumidity` and shows up with `humidity=0` in tdtool. This makes them show up in homekit, which is a bit annoying.

Please see this example:

```
○ tdtool --list-sensors
type=sensor protocol=mandolyn   model=temperaturehumidity   id=31   temperature=4.4 humidity=68 time=2016-10-09 18:18:54    age=10
type=sensor protocol=mandolyn   model=temperaturehumidity   id=11   temperature=23.7    humidity=33 time=2016-10-09 18:18:54    age=10
type=sensor protocol=mandolyn   model=temperaturehumidity   id=142  temperature=22.7    humidity=0  time=2016-10-09 18:18:06    age=58
type=sensor protocol=mandolyn   model=temperaturehumidity   id=113  temperature=23.9    humidity=34 time=2016-10-09 18:18:07    age=57
type=sensor protocol=mandolyn   model=temperaturehumidity   id=114  temperature=24.7    humidity=14 time=2016-10-09 18:18:22    age=42
type=sensor protocol=mandolyn   model=temperaturehumidity   id=41   temperature=25.2    humidity=0  time=2016-10-09 18:18:32    age=32
type=sensor protocol=mandolyn   model=temperaturehumidity   id=121  temperature=5.4 humidity=0  time=2016-10-09 18:18:37    age=27
type=sensor protocol=mandolyn   model=temperaturehumidity   id=61   temperature=9.9 humidity=67 time=2016-10-09 18:15:05    age=239
type=sensor protocol=mandolyn   model=temperaturehumidity   id=74   temperature=-19.6   humidity=0  time=2016-10-09 17:57:09    age=1315
```

A proper sensor should however never be able to reach 0, so we can identify these already when setting up sensors. There are probably many ways to do it, but I propose the following as it's easy to understand and covers the usecases I can think of.
