### PR TITLE
Fix: Avoid passing old sensor information to homekit.

### DIFF
--- a/src/lib/tdtool.js
+++ b/src/lib/tdtool.js
@@ -56,8 +56,9 @@ const TDtool = {
   device: id => TDtool.listDevices().then(
     devices => devices.find(d => d.id === id)),
 
+  // Sensors typically report once a minute, ignore them if they fail for 10 minutes.
   sensor: id => TDtool.listSensors().then(
-    sensors => sensors.find(s => s.id === id)),
+    sensors => sensors.find(s => s.id === id && s.age <= (60 * 10))),
 
   run: (cmd, target) => TDtool.isInstalled().then(() =>
     execute(`tdtool ${cmd} ${target}`)),


### PR DESCRIPTION
Sensors that have been seen by tdtool will be kept in memory until the `telldusd` service is restarted. This opens a potential risk of getting wrong information sent to homekit.

Example:

```
type=sensor protocol=mandolyn   model=temperaturehumidity   id=41   temperature=24.6    humidity=0  time=2016-10-11 01:21:35    age=51
type=sensor protocol=mandolyn   model=temperaturehumidity   id=121  temperature=1.8 humidity=0  time=2016-10-11 01:21:40    age=46
type=sensor protocol=mandolyn   model=temperaturehumidity   id=61   temperature=9.2 humidity=66 time=2016-10-10 12:31:06    age=46280
```

This PR fixes this by ignoring sensors which have not responded in 10 times the normal reporting time.
