### PR TITLE
Use config.json for configuring sensors.

### DIFF
--- a/spec/telldus-platform.spec.js
+++ b/spec/telldus-platform.spec.js
@@ -45,7 +45,7 @@ describe('test', () => {
         expect(accessories).toEqual([])
         expect(log.calls.allArgs()[0][0]).toEqual('Loading devices...')
         expect(log.calls.allArgs()[1][0]).toEqual(
-          'Found no items of type "device".')
+          'Found no items of type "device" from "tdtool --list-devices".')
         done()
       })
     })
@@ -69,7 +69,7 @@ describe('test', () => {
       instance.accessories(accessories => {
         expect(log.calls.allArgs()[0][0]).toEqual('Loading devices...')
         expect(log.calls.allArgs()[1][0]).toEqual(
-          'Found 1 item of type "device".')
+          'Found 1 item of type "device" from "tdtool --list-devices".')
         done()
       })
     })
@@ -111,7 +111,7 @@ describe('test', () => {
         })
         expect(log.calls.allArgs()[0][0]).toEqual('Loading devices...')
         expect(log.calls.allArgs()[1][0]).toEqual(
-          'Found 2 items of type "device".')
+          'Found 2 items of type "device" from "tdtool --list-devices".')
         done()
       })
     })

--- a/src/lib/telldus-accessory.js
+++ b/src/lib/telldus-accessory.js
@@ -215,8 +215,12 @@ class TelldusHygrometer extends TelldusAccessory {
   getHumidity(callback, context) {
     this.log('Checking humidity...')
     TDtool.sensor(this.id, this.log).then(s => {
-      this.log(`Found humidity ${s.humidity}%`)
-      callback(null, parseFloat(s.humidity))
+      if (s === undefined) {
+        callback(true, null)
+      } else {
+        this.log(`Found humidity ${s.humidity}%`)
+        callback(null, parseFloat(s.humidity))
+      }
     })
   }
 
@@ -266,8 +270,12 @@ class TelldusThermometer extends TelldusAccessory {
   getTemperature(callback, context) {
     this.log(`Checking temperature...`)
     TDtool.sensor(this.id, this.log).then(s => {
-      this.log(`Found temperature ${s.temperature}`)
-      callback(null, parseFloat(s.temperature))
+      if (s === undefined) {
+        callback(true, null)
+      } else {
+        this.log(`Found temperature ${s.temperature}`)
+        callback(null, parseFloat(s.temperature))
+      }
     })
   }
 
@@ -313,8 +321,12 @@ class TelldusThermometerHygrometer extends TelldusThermometer {
   getHumidity(callback, context) {
     this.log('Checking humidity...')
     TDtool.sensor(this.id, this.log).then(s => {
-      this.log(`Found humidity ${s.humidity}%`)
-      callback(null, parseFloat(s.humidity))
+      if (s === undefined) {
+        callback(true, null)
+      } else {
+        this.log(`Found humidity ${s.humidity}%`)
+        callback(null, parseFloat(s.humidity))
+      }
     })
   }
 


### PR DESCRIPTION
This PR adds the functionality to use config file as documented in https://github.com/amlinger/homebridge-telldus-tdtool/issues/30

```
"platforms": [
        {
            "name": "TellstickDuo",
            "platform": "Telldus-TD-Tool",
            "sensors": [
                {
                    "id": 114,
                    "model": "temperaturehumidity",
                    "name": "Bathroom"
                },
                {
                    "id": 142,
                    "model": "temperature",
                    "name": "Sauna"
                },
                {
                    "id": 74,
                    "model": "temperature",
                    "name": "Freezer"
                }
            ]
        }
    ]
```
- Leaving out the `sensors` array or adding an empty array, it will work as before (Except the removed feature override sensortype, since that is done in config file)
- Adding a `sensors` array brings the following features:
  - No false sensors will show up.
  - Setting the name in `config.json` ensures it's always the same (correct) name.
  - Setting the proper model in `config.json` allows reconfiguration of false `temperaturehumidity` as `temperature`.

Each sensor need to have two mandatory members, `id` (to identify it uniquely) and `model` (since we don't know that at this stage).
