### PR TITLE
Support the Elgato Eve App 2.5 by always including the name of the se…

### DIFF
--- a/src/lib/telldus-accessory.js
+++ b/src/lib/telldus-accessory.js
@@ -134,7 +134,7 @@ class TelldusSwitch extends TelldusAccessory {
    */
   getServices() {
     this.log('getServices called')
-    const controllerService = new this.Service.Lightbulb()
+    const controllerService = new this.Service.Lightbulb(this.name)
 
     controllerService.getCharacteristic(this.Characteristic.On)
       .on('get', this.getState.bind(this))
@@ -246,7 +246,7 @@ class TelldusHygrometer extends TelldusAccessory {
    * @return {Array} An array of services supported by this accessory.
    */
   getServices() {
-    const controllerService = new this.Service.HumiditySensor()
+    const controllerService = new this.Service.HumiditySensor(this.name)
 
     controllerService.getCharacteristic(
       this.Characteristic.CurrentRelativeHumidity
@@ -305,7 +305,7 @@ class TelldusThermometer extends TelldusAccessory {
    * @return {Array} An array of services supported by this accessory.
    */
   getServices() {
-    const controllerService = new this.Service.TemperatureSensor()
+    const controllerService = new this.Service.TemperatureSensor(this.name)
 
     controllerService.getCharacteristic(
       this.Characteristic.CurrentTemperature
@@ -355,7 +355,7 @@ class TelldusThermometerHygrometer extends TelldusThermometer {
    */
   getServices() {
     const thermoServices = super.getServices(),
-      hygroSensor = new this.Service.HumiditySensor()
+      hygroSensor = new this.Service.HumiditySensor(this.name)
 
     hygroSensor.getCharacteristic(
       this.Characteristic.CurrentRelativeHumidity


### PR DESCRIPTION
…nsor to the constructor.

The release of the Elgato Eve App v2.5 made all telldus sensors and switches disappear. They were still visible in accessory view, as well as homekit.

See discussion and screenshots: https://twitter.com/jannylund/status/799140512540266496

This PR fixes the issue. Solution found from looking at another homebridge plugin.