### PR TITLE
Better error message visibility on startup

### DIFF
--- a/spec/telldus-platform.spec.js
+++ b/spec/telldus-platform.spec.js
@@ -39,6 +39,7 @@ describe('test', () => {
       'tellstick-confparser': jasmine.createSpy(),
       './lib/tdtool': {
         TDtool: mockClass({
+          isInstalled: () => Promise.resolve(),
           listDevices: jasmine.createSpy().and.returnValue(null),
         })
       }
@@ -53,6 +54,7 @@ describe('test', () => {
         'tellstick-confparser': jasmine.createSpy(),
         './lib/tdtool': {
           TDtool: mockClass({
+            isInstalled: () => Promise.resolve(),
             listDevices: jasmine.createSpy().and.returnValue(Promise.resolve([])),
             listSensors: jasmine.createSpy().and.returnValue(Promise.resolve([])),
           })
@@ -78,6 +80,7 @@ describe('test', () => {
         'tellstick-confparser': jasmine.createSpy(),
         './lib/tdtool': {
           TDtool: mockClass({
+            isInstalled: () => Promise.resolve(),
             listDevices: jasmine.createSpy().and.returnValue(
               Promise.resolve(devices)),
             device: jasmine.createSpy().and.callFake(id =>
@@ -117,6 +120,7 @@ describe('test', () => {
         'tellstick-confparser': jasmine.createSpy(),
         './lib/tdtool': {
           TDtool: mockClass({
+            isInstalled: () => Promise.resolve(),
             listDevices: jasmine.createSpy().and.returnValue(
               Promise.resolve(devices)),
             device: jasmine.createSpy().and.callFake(id =>

--- a/spec/telldus-platform.spec.js
+++ b/spec/telldus-platform.spec.js
@@ -2,6 +2,19 @@
 
 const proxyquire = require('proxyquire')
 
+/*
+ * Method for creating a class with the mocked methods passed as
+ * arguments.
+ */
+const mockClass = (mocked) => (
+  class _Mock {
+    constructor() {
+      Object.keys(mocked).forEach(m => {
+        this[m] = mocked[m]
+      })
+    }
+  })
+
 describe('test', () => {
   let instance, log, homebridgeInjector
 
@@ -25,10 +38,13 @@ describe('test', () => {
     registerInjector({
       'tellstick-confparser': jasmine.createSpy(),
       './lib/tdtool': {
-        listDevices: jasmine.createSpy().and.returnValue(null),
+        TDtool: mockClass({
+          listDevices: jasmine.createSpy().and.returnValue(null),
+        })
       }
     })
-    expect(Object.keys(instance)).toEqual(['log', 'config', 'homebridge'])
+    expect(Object.keys(instance)).toEqual([
+      'log', 'config', 'homebridge', 'tdTool'])
   })
 
   describe('#accessories', () => {
@@ -36,8 +52,10 @@ describe('test', () => {
       registerInjector({
         'tellstick-confparser': jasmine.createSpy(),
         './lib/tdtool': {
-          listDevices: jasmine.createSpy().and.returnValue(Promise.resolve([])),
-          listSensors: jasmine.createSpy().and.returnValue(Promise.resolve([])),
+          TDtool: mockClass({
+            listDevices: jasmine.createSpy().and.returnValue(Promise.resolve([])),
+            listSensors: jasmine.createSpy().and.returnValue(Promise.resolve([])),
+          })
         }
       })
 
@@ -59,10 +77,12 @@ describe('test', () => {
       registerInjector({
         'tellstick-confparser': jasmine.createSpy(),
         './lib/tdtool': {
-          listDevices: jasmine.createSpy().and.returnValue(
-            Promise.resolve(devices)),
-          device: jasmine.createSpy().and.callFake(id =>
-            Promise.resolve(devices.find(d => d.id === id)))
+          TDtool: mockClass({
+            listDevices: jasmine.createSpy().and.returnValue(
+              Promise.resolve(devices)),
+            device: jasmine.createSpy().and.callFake(id =>
+              Promise.resolve(devices.find(d => d.id === id)))
+          })
         }
       })
 
@@ -96,11 +116,13 @@ describe('test', () => {
       registerInjector({
         'tellstick-confparser': jasmine.createSpy(),
         './lib/tdtool': {
-          listDevices: jasmine.createSpy().and.returnValue(
-            Promise.resolve(devices)),
-          device: jasmine.createSpy().and.callFake(id =>
-            Promise.resolve(devices.find(d => d.id === id))),
-          listSensors: jasmine.createSpy().and.returnValue(Promise.resolve([]))
+          TDtool: mockClass({
+            listDevices: jasmine.createSpy().and.returnValue(
+              Promise.resolve(devices)),
+            device: jasmine.createSpy().and.callFake(id =>
+              Promise.resolve(devices.find(d => d.id === id))),
+            listSensors: jasmine.createSpy().and.returnValue(Promise.resolve([]))
+          })
         }
       })
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const TDtool = require('./lib/tdtool')
+const {TDtool} = require('./lib/tdtool')
 const {
   TelldusSwitch,
   TelldusDimmer,
@@ -33,11 +33,12 @@ class TelldusTDToolPlatform {
     this.log = log
     this.config = config
     this.homebridge = homebridge
+    this.tdTool = new TDtool()
   }
 
   accessories(callback) {
     this.log('Loading devices...')
-    TDtool.listDevices().then(deviceCandidates => {
+    this.tdTool.listDevices().then(deviceCandidates => {
       const devices = deviceCandidates.filter(d => d.type === 'device')
       this.log(foundOfTypeString(
             'device', devices.length, 'tdtool --list-devices'))
@@ -53,7 +54,7 @@ class TelldusTDToolPlatform {
         })
         return devices.concat(this.config.sensors)
       } else {
-        return TDtool.listSensors().then(sensors => {
+        return this.tdTool.listSensors().then(sensors => {
           this.log(foundOfTypeString('sensor', sensors.length,
                 'tdtool --list-sensors'))
           sensors.forEach((current, index) => {
@@ -75,7 +76,7 @@ class TelldusTDToolPlatform {
           return null
         }
 
-        return new Accessory(data, this.log, this.homebridge, this.config)
+        return new Accessory(data, this.log, this.tdTool, this.homebridge, this.config)
       }).filter(
         accessory => accessory != null
       ))

--- a/src/index.js
+++ b/src/index.js
@@ -33,12 +33,15 @@ class TelldusTDToolPlatform {
     this.log = log
     this.config = config
     this.homebridge = homebridge
-    this.tdTool = new TDtool()
+    this.tdTool = new TDtool(log)
   }
 
   accessories(callback) {
     this.log('Loading devices...')
-    this.tdTool.listDevices().then(deviceCandidates => {
+
+    this.tdTool.isInstalled().then(() => {
+      return this.tdTool.listDevices()
+    }).then(deviceCandidates => {
       const devices = deviceCandidates.filter(d => d.type === 'device')
       this.log(foundOfTypeString(
             'device', devices.length, 'tdtool --list-devices'))
@@ -80,7 +83,12 @@ class TelldusTDToolPlatform {
       }).filter(
         accessory => accessory != null
       ))
-    }, error => callback(new Error(error)))
+    }, error => {
+      // If an error occurs, we can log it and return an empty set of
+      // accessories to not crash homebridge for other plugins.
+      this.log(`An error happened, stopped looking for devices: ${error}`)
+      callback([])
+    })
   }
 }
 

--- a/src/lib/tdtool.js
+++ b/src/lib/tdtool.js
@@ -10,6 +10,20 @@ const exec = require('child_process').exec
 const execute = cmd => new Promise((resolve, reject) => {
   exec(cmd, (err, stdout, stderr) => err ? reject(stderr) : resolve(stdout))})
 
+/**
+ * Accepts a device string, and returns a list of objects.
+ *
+ * The string is expected to have the following format
+ * type=device    id=1    name=First Lamp      lastsentcommand=OFF
+ * type=device    id=2    name=Second Lamp     lastsentcommand=OFF
+ * type=device    id=3    name=Another thing   lastsentcommand=ON
+ *
+ * Although this is generalized to key-value pairs separated by '=', pairs
+ * separated by tabs and objects separated by newlines.
+ *
+ * @param  {string} deviceString The string output from tdtool.
+ * @return {List}                A list of objects found in the given string.
+ */
 const deviceStringToObjects = deviceString =>
   deviceString
     .split(LINE_DELIMETER)
@@ -24,64 +38,173 @@ const deviceStringToObjects = deviceString =>
 
 
 /**
- * Wrapper for CMD interaction with
- * @type {Object}
+ * Wrapper for command line interactions with the CLI tool tdtool,
+ * provided as part of telldus-core.
+ *
+ * This can be used for listing what tdtool refers to as either sensors using
+ * the TDtool#listSensors method, or devices using the TDtool#listDevices
+ * method, respectively.
+ *
+ * A sensor is an object containing fields listed by tdtool --list-sensors.
+ * A device is an object containing fields listed by tdtool --list-devices.
+ *
+ * @type {TDtool}
  */
 class TDtool {
-  isInstalled() {
-    return execute('command -v tdtool').then(res => {
-      (res !== '') ? Promise.resolve() : Promise.reject(
-        '"tdtool" does not seem to be installed, but is required by this plugin.')})
+  constructor(log) {
+    this.log = string => log(`[TDtool]: ${string}`)
   }
 
+  /**
+   * Verify that TDtool is installed on the system.
+   *
+   * This check is wrapped in a Promise, to be resolved if the system has got
+   * tdtool installed, or reject with an error message otherwise. The method
+   * used for this is:
+   * ```
+   * command -v tdtool
+   * ```
+   *
+   * @return {Promise} Promise that will resolve if tdtool is installed on
+   *         the system, and rejected otherwise.
+   */
+  isInstalled() {
+    this.log('Checking whether TDtool is installed (command -v tdtool)...')
+    return execute('command -v tdtool').then(res => {
+      if (res != '') {
+        this.log('"TDtool" is present on system.')
+        Promise.resolve()
+      } else {
+        this.log('"tdtool" does not seem to be installed, but is required ' +
+                 'by this plugin.')
+        Promise.reject('Necessary dependency missing')
+      }
+    })
+  }
+
+  /**
+   * Returns a list of all devices found using tdtool.
+   *
+   * For devices to be returned, they both need to be present
+   * using `tdtool --list-devices`, and listed in '/etc/tellstick.conf'.
+   * The file is parsed using 'tellstick.conf-parser'.
+   *
+   * @return {Promise} Promise that is resolved with the devices from
+   *                   `tdtool --list-devices`. This is a list of
+   *                   device objects with fields as listed by stdout,
+   *                   augmented and merged with objects as found in
+   *                   tellstick.conf.
+   */
   listDevices() {
-    return this.isInstalled().then(() =>
-      execute('tdtool --list-devices')
-    ).then(deviceString => {
+    return execute('tdtool --list-devices').then(deviceString => {
+      const tdtoolDevices = deviceStringToObjects(deviceString)
+      // TODO: Validate the resuls from this, and that the correct properties
+      // are present.
+
+      this.log('"tdtool --list-devices" lists ' +
+               tdtoolDevices.map(d => `"${d.name}"`).join(', '))
+
       return confParser.parse('/etc/tellstick.conf').then(conf => {
-        return deviceStringToObjects(deviceString)
+        this.log('"/etc/tellstick.conf" lists ' +
+                 conf.devices.map(d => `"${d.name}"`).join(', '))
+
+        return tdtoolDevices
           .map(device => Object.assign(
             conf.devices.find(confDev => confDev.id === device.id), device))
       })
     })
   }
 
+  /**
+   * Lists sensors found by tdtool command.
+   *
+   * The main difference from listing devices is that this cannot be
+   * controlled by anything, and are read-only. These are listed using
+   *
+   * @return {Promise} Promise that is resolved with the sensors from
+   *                   `tdtool --list-sensors`. This is a list of
+   *                   sensor objects with fields as listed by stdout.
+   */
   listSensors() {
-    return this.isInstalled().then(() =>
-      execute('tdtool --list-sensors')
-    ).then(deviceString =>
-      deviceStringToObjects(deviceString))
+    return execute('tdtool --list-sensors').then(deviceString => {
+      const tdtoolSensors = deviceStringToObjects(deviceString)
+      this.log('"tdtool --list-sensors" lists ' +
+               tdtoolSensors.map(d => `"${d.id}"`).join(', '))
+      return tdtoolSensors
+    })
   }
 
+  /**
+   * Finds the device with the given ID.
+   *
+   * Note that this uses listDevices under the hood, so each call to this
+   * method is rather inefficient, and might be time-consuming.
+   *
+   * @param {any}      id ID for the device to return.
+   * @return {Promise}    Promise that is resolved with the device object as
+   *                      found in the list.
+   */
   device(id) {
     return this.listDevices().then(
       devices => devices.find(d => d.id === id))
   }
 
+  /**
+   * Finds the sensor with the given ID.
+   *
+   * Note that this uses listSensors under the hood, so each call to this
+   * method is rather inefficient, and might be time-consuming.
+   *
+   * @param {any}      id ID for the sensor to return.
+   * @return {Promise}    Promise that is resolved with the sensor object as
+   *                      found in the list.
+   */
   sensor(id) {
     return this.listSensors().then(
       sensors => sensors.find(s => s.id === id))
   }
 
-  run(cmd, target) {
-    return this.isInstalled().then(() =>
-      execute(`tdtool ${cmd} ${target}`))
-  }
+  /**
+   * Run a command using TDtool CLI.
+   *
+   * @param  {string} cmd    The command to run on the target (Ex: '--on-).
+   * @param  {any}    target The target to run the command on.
+   * @return {Promise}       A Promise that when resolved, contains the stdout
+   *                         response to the invoked command, or the stderr
+   *                         output when rejected.
+   */
+  run(cmd, target) { return execute(`tdtool ${cmd} ${target}`) }
 
   /**
-   * Shorthand methods for running a command on a Device with the given
-   * Device ID.
+   * Shorthand method for invoking an on command on a device.
    *
-   * @param  {[type]} TDtool [description]
-   * @param  {[type]} '--on' [description]
-   * @return {[type]}        [description]
+   * @param  {int}     id ID of the sensor to invoke the on command for.
+   * @return {Promise}    A Promise that when resolved, contains the stdout
+   *                      response to the invoked command, or the stderr
+   *                      output when rejected.
    */
   on(id) { return this.run('--on', id) }
+
+  /**
+   * Shorthand method for invoking an off command on a device.
+   *
+   * @param  {int}     id  ID of the sensor to invoke the off command for.
+   * @return {Promise}     A Promise that when resolved, contains the stdout
+   *                       response to the invoked command, or the stderr
+   *                       output when rejected.
+   */
   off(id) { return this.run('--off', id) }
-  dim(level, id) {
-    return this.isInstalled().then(() =>
-      execute(`tdtool --dimlevel ${level} --dim ${id}`))
-  }
+
+  /**
+   * Shorthand method for invoking a dim command on a device.
+   *
+   * @param  {int}     id    ID of the sensor to invoke the dim command for.
+   * @param  {level}   level The level to dim to for the device with given ID.
+   * @return {Promise}       A Promise that when resolved, contains the stdout
+   *                         response to the invoked command, or the stderr
+   *                         output when rejected.
+   */
+  dim(level, id) { return execute(`tdtool --dimlevel ${level} --dim ${id}`) }
 }
 
 module.exports = { TDtool }

--- a/src/lib/tdtool.js
+++ b/src/lib/tdtool.js
@@ -27,15 +27,15 @@ const deviceStringToObjects = deviceString =>
  * Wrapper for CMD interaction with
  * @type {Object}
  */
-const TDtool = {
-  isInstalled: () => execute('command -v tdtool').then(res =>
-    (res !== '') ? Promise.resolve() : Promise.reject(
-      '"tdtool" does not seem to be installed, but is required by this plugin.'
-    )
-  ),
+class TDtool {
+  isInstalled() {
+    return execute('command -v tdtool').then(res => {
+      (res !== '') ? Promise.resolve() : Promise.reject(
+        '"tdtool" does not seem to be installed, but is required by this plugin.')})
+  }
 
-  listDevices: () => {
-    return TDtool.isInstalled().then(() =>
+  listDevices() {
+    return this.isInstalled().then(() =>
       execute('tdtool --list-devices')
     ).then(deviceString => {
       return confParser.parse('/etc/tellstick.conf').then(conf => {
@@ -44,23 +44,29 @@ const TDtool = {
             conf.devices.find(confDev => confDev.id === device.id), device))
       })
     })
-  },
+  }
 
-  listSensors: () => {
-    return TDtool.isInstalled().then(() =>
+  listSensors() {
+    return this.isInstalled().then(() =>
       execute('tdtool --list-sensors')
     ).then(deviceString =>
       deviceStringToObjects(deviceString))
-  },
+  }
 
-  device: id => TDtool.listDevices().then(
-    devices => devices.find(d => d.id === id)),
+  device(id) {
+    return this.listDevices().then(
+      devices => devices.find(d => d.id === id))
+  }
 
-  sensor: id => TDtool.listSensors().then(
-    sensors => sensors.find(s => s.id === id)),
+  sensor(id) {
+    return this.listSensors().then(
+      sensors => sensors.find(s => s.id === id))
+  }
 
-  run: (cmd, target) => TDtool.isInstalled().then(() =>
-    execute(`tdtool ${cmd} ${target}`)),
+  run(cmd, target) {
+    return this.isInstalled().then(() =>
+      execute(`tdtool ${cmd} ${target}`))
+  }
 
   /**
    * Shorthand methods for running a command on a Device with the given
@@ -70,10 +76,12 @@ const TDtool = {
    * @param  {[type]} '--on' [description]
    * @return {[type]}        [description]
    */
-  on:  id => TDtool.run('--on', id),
-  off: id => TDtool.run('--off', id),
-  dim: (level, id) => TDtool.isInstalled().then(() =>
-      execute(`tdtool --dimlevel ${level} --dim ${id}`)),
+  on(id) { return this.run('--on', id) }
+  off(id) { return this.run('--off', id) }
+  dim(level, id) {
+    return this.isInstalled().then(() =>
+      execute(`tdtool --dimlevel ${level} --dim ${id}`))
+  }
 }
 
-module.exports = TDtool
+module.exports = { TDtool }


### PR DESCRIPTION
To make the project a tad more user-friendly, this attempts to show better error messages during startup. To look at the issue more broadly, this involves:
* Passing a log handle to TDtool.js, and log methods and outcomes of them. 
* Complete documentation for TDtool.js, to better show what a method attempts to achieve.
* Check whether tdtool is installed on startup of finding the accessories. By doing this, the install check can be removed from other methods, as we work under the assumption that it is installed when invoking these (or else, the returned Promise will be rejected). This will improve the response time of the tool, slightly.
