### PR TITLE
Close #54: Cleanup reading of tellstick.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,21 @@ Below is the supported attributes for the sensor list.
 |  `model`  |   _Required_   | See below for supported models                  |
 | `maxAge`  |     `3600`     | Seconds from last update until considered stale |
 
+#### Configuring TDtool
+
+If your `tellstick.conf` is located anywhere other than `/etc/tellstick.conf`,
+the following can be used to specify a custom location:
+
+```json
+{
+  "platform" : "Telldus-TD-Tool",
+  "name" : "Telldus-TD-Tool",
+  "tdtool": {
+    "tellstickConfLocation": "/home/pi/tellstick.configuration"
+  }
+}
+```
+
 #### Supported accessories
 
 |         Model         |           Backed by            |

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ class TelldusTDToolPlatform {
     this.log = log
     this.config = config
     this.homebridge = homebridge
-    this.tdTool = new TDtool(log)
+    this.tdTool = new TDtool(log, config.tdtool)
   }
 
   accessories(callback) {


### PR DESCRIPTION
Only read tellstick.conf once when first needed, and listen for error
messages thrown by tellstick.conf-parser.

This will provide better error handling when reading the conf file, together with https://github.com/amlinger/tellstick.conf-parser/issues/5